### PR TITLE
Implement doorbell direct streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Seamlessly integrate ONVIF-compliant cameras and Reolink POE Doorbells into Smar
 
 🔧 Supports NVR-based streaming (Reolink RLN36).
 
+🔔 Doorbell presses override NVR routing to stream and snapshot directly from the camera.
+
+📺 View cameras as Action Tiles or combine them in a Camera Group.
+
 ⚙️ Requirements
 SmartThings Hub (Edge compatible)
 
@@ -40,6 +44,8 @@ For Doorbells:
 Receive push notifications on press.
 
 Use two-way audio and chime controls via SmartThings app.
+
+Doorbell video and snapshots use the camera directly while other streams go through the NVR.
 
 Add devices to a Camera Group for live streaming view.
 

--- a/hubpackage/src/commands.lua
+++ b/hubpackage/src/commands.lua
@@ -15,7 +15,10 @@ local M = {}
 ----------------------------------------------------
 -- STREAM URL GENERATION WITH NVR CHANNEL SUPPORT
 ----------------------------------------------------
-function M.get_stream_url(device)
+-- get_stream_url(device[, bypass_nvr])
+-- Returns an RTSP URL. When bypass_nvr is true the camera IP is used even if
+-- USENVRSTREAM is enabled.
+function M.get_stream_url(device, bypass_nvr)
   local username = device.preferences.username or config.DEFAULT_USER
   local password = device.preferences.password or config.DEFAULT_PASS
   local cam_ip = device.preferences.ipAddress
@@ -25,16 +28,16 @@ function M.get_stream_url(device)
     return string.format("rtsp://%s:%s@%s:554/Preview_%02d_%s", username, password, ip, ch, stream)
   end
 
-  -- Try NVR stream first
-  if config.USENVRSTREAM and config.NVR_IP then
+  -- Try NVR stream first unless direct access was requested
+  if not bypass_nvr and config.USENVRSTREAM and config.NVR_IP then
     local nvr_url = build_rtsp(config.NVR_IP, channel, "main")
     log.debug("📡 Using NVR stream URL: " .. nvr_url)
     return nvr_url
   end
 
-  -- Fallback to direct camera stream
+  -- Direct camera stream
   local direct_url = build_rtsp(cam_ip, 1, "main")
-  log.debug("📡 Fallback to camera stream URL: " .. direct_url)
+  log.debug("📡 Using camera stream URL: " .. direct_url)
   return direct_url
 end
 
@@ -64,10 +67,13 @@ end
 ----------------------------------------------------
 -- SNAPSHOT URL EMISSION WITH CACHE BUSTING TIMESTAMP
 ----------------------------------------------------
-function M.refresh_snapshot(device)
+-- refresh_snapshot(device[, bypass_nvr])
+-- Emit a JPEG snapshot event. When bypass_nvr is true the camera IP is used
+-- instead of the NVR.
+function M.refresh_snapshot(device, bypass_nvr)
   local username = device.preferences.username or config.DEFAULT_USER
   local password = device.preferences.password or config.DEFAULT_PASS
-  local ip = config.USENVRSTREAM and config.NVR_IP or device.preferences.ipAddress
+  local ip = (not bypass_nvr and config.USENVRSTREAM and config.NVR_IP) or device.preferences.ipAddress
   local channel = device:get_field("nvr_channel") or 0
   local now = os.time()
 

--- a/hubpackage/src/config.lua
+++ b/hubpackage/src/config.lua
@@ -35,6 +35,12 @@ M.EMIT_CUSTOM_EVENTS = true
 M.ALLOW_HTTPS = true
 M.FORCE_HTTP = false
 
+-- ONVIF Event Polling Interval (seconds)
+M.BACKOFF_BASE = 10
+
+-- Verbose logging toggle
+M.DEBUG_MODE = false
+
 -- Default Device Profile Map
 M.DEFAULT_PROFILES = {
   doorbell = "snapshot-tile-profile-doorbell",  -- corresponds to snapshot-tile-profile-doorbell.yaml

--- a/hubpackage/src/event_handlers.lua
+++ b/hubpackage/src/event_handlers.lua
@@ -66,8 +66,15 @@ function M.handle_doorbell_press(device)
     device:emit_event(capabilities["pianodream12480.doorbell"].button("pressed"))
   end
 
-  -- Always refresh snapshot to update tile (even if motion missed it)
-  commands.refresh_snapshot(device)
+  -- Always refresh snapshot using direct camera connection
+  commands.refresh_snapshot(device, true)
+
+  -- Emit direct stream URL for PIP or notifications
+  local stream_url = commands.get_stream_url(device, true)
+  device:emit_event(capabilities.videoStream.stream({
+    url = stream_url,
+    protocol = "rtsp"
+  }))
 end
 
 -- Motion Detected → Trigger Snapshot

--- a/hubpackage/src/init.lua
+++ b/hubpackage/src/init.lua
@@ -39,20 +39,6 @@ local function emit_video_stream(device)
   -- Example: map NVR channel X to virtual device and update its tile too (deferred, pending prototype validation)
 end
 
--- Trigger snapshot on doorbell ring (if motion doesn't catch it)
-local function handle_doorbell_press(device)
-  if config.EMIT_STANDARD_EVENTS then
-    device:emit_event(capabilities.button.button.pushed({ state_change = true }))
-    log.info("🔔 Standard doorbell event emitted for SmartThings TV/Fridge")
-  end
-  if config.EMIT_CUSTOM_EVENTS then
-    device:emit_event(cap_doorbell.button("pressed"))
-    log.info("🔔 Custom doorbell event emitted")
-  end
-
-  -- Always refresh snapshot on button press to update tile view
-  commands.refresh_snapshot(device)
-end
 
 -- Lifecycle Init
 local function init_device(driver, device)

--- a/hubpackage/src/init.lua
+++ b/hubpackage/src/init.lua
@@ -39,6 +39,11 @@ local function emit_video_stream(device)
   -- Example: map NVR channel X to virtual device and update its tile too (deferred, pending prototype validation)
 end
 
+-- Handle doorbell ring events
+local function handle_doorbell_press(device)
+  event_handlers.handle_doorbell_press(device)
+end
+
 
 -- Lifecycle Init
 local function init_device(driver, device)


### PR DESCRIPTION
## Summary
- use `bypass_nvr` flag when requesting a stream or snapshot
- document viewing via Action Tiles / Camera Groups
- remove unused local doorbell handler

## Testing
- `luac -p hubpackage/src/commands.lua`
- `luac -p hubpackage/src/event_handlers.lua`
- `luac -p hubpackage/src/init.lua`
- `npm test` *(fails: package.json missing)*
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_68433911f804832e9457abc0ad4b342a