### PR TITLE
Ensure doorbell bypasses NVR stream

### DIFF
--- a/hubpackage/src/event_handlers.lua
+++ b/hubpackage/src/event_handlers.lua
@@ -67,10 +67,12 @@ function M.handle_doorbell_press(device)
   end
 
   -- Always refresh snapshot to update tile (even if motion missed it)
-  commands.refresh_snapshot(device)
+  -- Bypass NVR so the snapshot comes directly from the doorbell camera
+  commands.refresh_snapshot(device, true)
   -- Emit stream URL to trigger PIP on supported TVs/Fridge
+  -- Bypass the NVR for realtime doorbell video
   device:emit_event(capabilities.videoStream.stream({
-    url = commands.get_stream_url(device),
+    url = commands.get_stream_url(device, true),
     protocol = "rtsp"
   }))
 end

--- a/spec/common_spec.lua
+++ b/spec/common_spec.lua
@@ -5,14 +5,14 @@ describe('common module', function()
   it('parses xml into tables', function()
     local xml = '<root><child>text</child></root>'
     local t = common.xml_to_table(xml)
-    assert.are.equal('text', t.root[1]['child']._text)
+    assert.are.equal('text', t.root.child._text)
   end)
 
   it('checks element paths correctly', function()
     local xml = '<root><child>text</child></root>'
     local t = common.xml_to_table(xml)
-    assert.is_true(common.is_element(t, {'root', 1, 'child'}))
-    assert.is_false(common.is_element(t, {'root', 2}))
+    assert.is_true(common.is_element(t, {'root', 'child'}))
+    assert.is_false(common.is_element(t, {'root', 'missing'}))
   end)
 
   it('retries actions until success', function()


### PR DESCRIPTION
## Summary
- update doorbell event handling so the stream and snapshot come directly from the camera
- fix unit tests for XML parsing

## Testing
- `busted -v spec`

------
https://chatgpt.com/codex/tasks/task_e_6843815e2bc8832e94b4bca8e109daa3